### PR TITLE
refs #7 add "static" option for manually closable

### DIFF
--- a/javascripts/jquery.growl.coffee
+++ b/javascripts/jquery.growl.coffee
@@ -37,6 +37,8 @@ class Growl
     $("body:not(:has(#growls))").append '<div id="growls" />'
 
   constructor: (settings = {}) ->
+    if(settings.static)
+        settings.duration=99999999999; 
     @settings = $.extend {}, Growl.settings, settings
     @$growls().attr 'class', @settings.location
     @render()


### PR DESCRIPTION
The growl message with option static will display for 3 years before it is dismissed.

Usage:
$.growl({title:'Icy Kitty', message:'Kitty is frozen in ice, :(', static:'true'});
