### PR TITLE
Changed Entity for &times; to &#215;

### DIFF
--- a/javascripts/jquery.growl.js
+++ b/javascripts/jquery.growl.js
@@ -43,7 +43,7 @@ Copyright 2013 Kevin Sylvestre
     Growl.settings = {
       namespace: 'growl',
       duration: 3200,
-      close: "&times;",
+      close: "&#215;",
       location: "default",
       style: "default",
       size: "medium"


### PR DESCRIPTION
When using strict XHTML5 documents, the entity &times; is undefined. The
numeric representation '&#215;' works fine everywhere in every document
type.

This commit does not change any functionality.
