### PR TITLE
New message should show up at the top by default

### DIFF
--- a/javascripts/jquery.growl.coffee
+++ b/javascripts/jquery.growl.coffee
@@ -43,7 +43,7 @@ class Growl
 
   render: =>
     $growl = @$growl()
-    @$growls().append $growl
+    @$growls().prepend $growl
     if @settings.static? then @present() else @cycle()
     return
 


### PR DESCRIPTION
Changed `@$growls().append $growl` to `@$growls().prepend $growl`. Or should we provide it as an option?