### PR TITLE
Explicit deprecation warning and README addition

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Growl also supports some customization through the following options:
 - **size**: ('small' / 'medium' / 'large') customize the sizing of the alerts (default: 'medium')
 - **style**: ('default' / 'error' / 'notice' / 'warning') customize the styling of the alerts (default: 'default')
 - **location**: ('tl' / 'tr' / 'bl' / 'br' / 'tc' / 'bc') customize the position of the growl alerts (default: 'tr')
+- **duration**: seconds to display alert when fixed is false (default: 3200)
 
 ### Deprecations
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Growl also supports some customization through the following options:
 - **size**: ('small' / 'medium' / 'large') customize the sizing of the alerts (default: 'medium')
 - **style**: ('default' / 'error' / 'notice' / 'warning') customize the styling of the alerts (default: 'default')
 - **location**: ('tl' / 'tr' / 'bl' / 'br' / 'tc' / 'bc') customize the position of the growl alerts (default: 'tr')
-- **duration**: seconds to display alert when fixed is false (default: 3200)
+- **duration**: milliseconds to display alert when fixed is false (default: 3200)
 
 ### Deprecations
 

--- a/javascripts/jquery.growl.coffee
+++ b/javascripts/jquery.growl.coffee
@@ -47,7 +47,7 @@ class Growl
     
     # Note: static has been renamed to fixed and will be removed in the future
     if @settings['static']?
-      console?.debug?('DEPRECATION: static has been renamed to fix and will be removed in the next release')
+      console?.debug?('[jquery.growl] DEPRECATION WARNING: The option `static` has been renamed to `fixed` and will be removed in the next release')
       @settings['fixed'] = @settings['static'] 
 
     if @settings.fixed then @present() else @cycle()


### PR DESCRIPTION
Just noticed after implementing and testing.  The console output fails to announce who is throwing the dep warning.  Might be wise to prefix with the plugin name for clarity sake.  Also I missed the fact that the option was referred to as `fix` rather than `fixed`.  Sorry about that.