### PR TITLE
Add ability not to dismiss when mouse is over

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Growl also supports some customization through the following options:
 - **size**: ('small' / 'medium' / 'large') customize the sizing of the alerts (default: 'medium')
 - **style**: ('default' / 'error' / 'notice' / 'warning') customize the styling of the alerts (default: 'default')
 - **location**: ('tl' / 'tr' / 'bl' / 'br' / 'tc' / 'bc') customize the position of the growl alerts (default: 'tr')
+- **delayOnHover**: (true / false) permit the growl not to dismiss when mouse is over. When mouse leave (default: false)
 
 ### Deprecations
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Growl also supports some customization through the following options:
 - **size**: ('small' / 'medium' / 'large') customize the sizing of the alerts (default: 'medium')
 - **style**: ('default' / 'error' / 'notice' / 'warning') customize the styling of the alerts (default: 'default')
 - **location**: ('tl' / 'tr' / 'bl' / 'br' / 'tc' / 'bc') customize the position of the growl alerts (default: 'tr')
-- **delayOnHover**: (true / false) permit the growl not to dismiss when mouse is over. (default: false)
+- **delayOnHover**: (true / false) prevent the growl from dismissing when mouse is over. (default: true)
 
 ### Deprecations
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Growl also supports some customization through the following options:
 - **size**: ('small' / 'medium' / 'large') customize the sizing of the alerts (default: 'medium')
 - **style**: ('default' / 'error' / 'notice' / 'warning') customize the styling of the alerts (default: 'default')
 - **location**: ('tl' / 'tr' / 'bl' / 'br' / 'tc' / 'bc') customize the position of the growl alerts (default: 'tr')
-- **delayOnHover**: (true / false) permit the growl not to dismiss when mouse is over. When mouse leave (default: false)
+- **delayOnHover**: (true / false) permit the growl not to dismiss when mouse is over. (default: false)
 
 ### Deprecations
 

--- a/javascripts/jquery.growl.coffee
+++ b/javascripts/jquery.growl.coffee
@@ -28,7 +28,7 @@ class Growl
     location: "default"
     style: "default"
     size: "medium"
-    delayOnHover: false
+    delayOnHover: true
 
   @growl: (settings = {}) ->
     @initialize()

--- a/javascripts/jquery.growl.coffee
+++ b/javascripts/jquery.growl.coffee
@@ -28,6 +28,7 @@ class Growl
     location: "default"
     style: "default"
     size: "medium"
+    delayOnHover: false
 
   @growl: (settings = {}) ->
     @initialize()
@@ -49,11 +50,25 @@ class Growl
 
   bind: ($growl = @$growl()) =>
     $growl.on("click", @click)
+    if(@settings.delayOnHover)
+      $growl.on("mouseenter", @mouseEnter)
+      $growl.on("mouseleave", @mouseLeave)
     $growl.on("contextmenu", @close).find(".#{@settings.namespace}-close").on("click", @close)
 
   unbind: ($growl = @$growl()) =>
     $growl.off("click", @click)
+    if(@settings.delayOnHover)
+      $growl.off("mouseenter", @mouseEnter)
+      $growl.off("mouseleave", @mouseLeave)
     $growl.off("contextmenu", @close).find(".#{@settings.namespace}-close").off("click", @close)
+
+  mouseEnter: (event) =>
+    $growl = @$growl()
+    $growl
+      .stop(true,true)
+
+  mouseLeave: (event) =>
+    @waitAndDismiss()
 
   click: (event) =>
     if @settings.url?
@@ -74,6 +89,11 @@ class Growl
     $growl = @$growl()
     $growl
       .queue(@present)
+      .queue(@waitAndDismiss())
+
+  waitAndDismiss: =>
+    $growl = @$growl()
+    $growl
       .delay(@settings.duration)
       .queue(@dismiss)
       .queue(@remove)

--- a/javascripts/jquery.growl.js
+++ b/javascripts/jquery.growl.js
@@ -47,7 +47,7 @@ Copyright 2015 Kevin Sylvestre
       location: "default",
       style: "default",
       size: "medium",
-      delayOnHover: false
+      delayOnHover: true
     };
 
     Growl.growl = function(settings) {

--- a/javascripts/jquery.growl.js
+++ b/javascripts/jquery.growl.js
@@ -46,7 +46,8 @@ Copyright 2015 Kevin Sylvestre
       close: "&#215;",
       location: "default",
       style: "default",
-      size: "medium"
+      size: "medium",
+      delayOnHover: false
     };
 
     Growl.growl = function(settings) {
@@ -74,9 +75,12 @@ Copyright 2015 Kevin Sylvestre
       this.remove = bind(this.remove, this);
       this.dismiss = bind(this.dismiss, this);
       this.present = bind(this.present, this);
+      this.waitAndDismiss = bind(this.waitAndDismiss, this);
       this.cycle = bind(this.cycle, this);
       this.close = bind(this.close, this);
       this.click = bind(this.click, this);
+      this.mouseLeave = bind(this.mouseLeave, this);
+      this.mouseEnter = bind(this.mouseEnter, this);
       this.unbind = bind(this.unbind, this);
       this.bind = bind(this.bind, this);
       this.render = bind(this.render, this);
@@ -101,6 +105,10 @@ Copyright 2015 Kevin Sylvestre
         $growl = this.$growl();
       }
       $growl.on("click", this.click);
+      if (this.settings.delayOnHover) {
+        $growl.on("mouseenter", this.mouseEnter);
+        $growl.on("mouseleave", this.mouseLeave);
+      }
       return $growl.on("contextmenu", this.close).find("." + this.settings.namespace + "-close").on("click", this.close);
     };
 
@@ -109,7 +117,21 @@ Copyright 2015 Kevin Sylvestre
         $growl = this.$growl();
       }
       $growl.off("click", this.click);
+      if (this.settings.delayOnHover) {
+        $growl.off("mouseenter", this.mouseEnter);
+        $growl.off("mouseleave", this.mouseLeave);
+      }
       return $growl.off("contextmenu", this.close).find("." + this.settings.namespace + "-close").off("click", this.close);
+    };
+
+    Growl.prototype.mouseEnter = function(event) {
+      var $growl;
+      $growl = this.$growl();
+      return $growl.stop(true, true);
+    };
+
+    Growl.prototype.mouseLeave = function(event) {
+      return this.waitAndDismiss();
     };
 
     Growl.prototype.click = function(event) {
@@ -131,7 +153,13 @@ Copyright 2015 Kevin Sylvestre
     Growl.prototype.cycle = function() {
       var $growl;
       $growl = this.$growl();
-      return $growl.queue(this.present).delay(this.settings.duration).queue(this.dismiss).queue(this.remove);
+      return $growl.queue(this.present).queue(this.waitAndDismiss());
+    };
+
+    Growl.prototype.waitAndDismiss = function() {
+      var $growl;
+      $growl = this.$growl();
+      return $growl.delay(this.settings.duration).queue(this.dismiss).queue(this.remove);
     };
 
     Growl.prototype.present = function(callback) {


### PR DESCRIPTION
Hi,
I made a few changes to prevent the growl from dismissing when the mouse is over.
When the mouse enter, I stop the jQuery queue and when the mouse leave, I call again $growl.cycle() to go back to the delay and dismiss.
I added a setting to enable that to keep the current behaviour.

I also updated README for that settings.